### PR TITLE
Compare value length to used length () in reading data from message b…

### DIFF
--- a/erpc_c/infra/erpc_basic_codec.cpp
+++ b/erpc_c/infra/erpc_basic_codec.cpp
@@ -343,17 +343,21 @@ void BasicCodec::readBinary(uint32_t *length, uint8_t **value)
 
     if (isStatusOk())
     {
-        if (m_cursor.getRemaining() >= *length)
+        if (m_cursor.getRemainingUsed() < *length)
+        {
+            m_status = kErpcStatus_Fail;
+        }
+        else if (m_cursor.getRemaining() < *length)
+        {
+            m_status = kErpcStatus_BufferOverrun;
+        }
+        else
         {
             // Return current pointer into buffer.
             *value = m_cursor.get();
 
             // Skip over data.
             m_cursor += (uint16_t)*length;
-        }
-        else
-        {
-            m_status = kErpcStatus_BufferOverrun;
         }
     }
     if (!isStatusOk())

--- a/erpc_c/infra/erpc_message_buffer.hpp
+++ b/erpc_c/infra/erpc_message_buffer.hpp
@@ -119,7 +119,7 @@ public:
      *
      * @param[in] used Length of used space of buffer.
      */
-    void setUsed(uint16_t used) { m_used = used; }
+    void setUsed(uint16_t used);
 
     /*!
      * @brief This function read data from local buffer.
@@ -197,7 +197,6 @@ public:
         Cursor(void)
         : m_buffer(NULL)
         , m_pos(NULL)
-        , m_remaining(0)
         {
         }
 
@@ -208,10 +207,9 @@ public:
          *
          * @param[in] buffer MessageBuffer for sending/receiving.
          */
-        Cursor(MessageBuffer *buffer)
+        explicit Cursor(MessageBuffer *buffer)
         : m_buffer(buffer)
         , m_pos(buffer->get())
-        , m_remaining(buffer->getLength())
         {
         }
 
@@ -245,7 +243,14 @@ public:
          *
          * @return Remaining free space in current buffer.
          */
-        uint16_t getRemaining(void) const { return m_remaining; }
+        uint16_t getRemaining(void) const { return m_buffer->getLength() - (uint16_t)(m_pos - m_buffer->get()); }
+
+        /*!
+         * @brief Return remaining space from used of current buffer.
+         *
+         * @return Remaining space from used of current buffer.
+         */
+        uint16_t getRemainingUsed(void) const { return m_buffer->getUsed() - (uint16_t)(m_pos - m_buffer->get()); }
 
         /*!
          * @brief Read data from current buffer.
@@ -284,14 +289,14 @@ public:
          *
          * @param[in] index Index in buffer.
          */
-        uint8_t &operator[](int index) { return m_pos[index]; }
+        uint8_t &operator[](int index);
 
         /*!
          * @brief Array operator return value of buffer at given index.
          *
          * @param[in] index Index in buffer.
          */
-        const uint8_t &operator[](int index) const { return m_pos[index]; }
+        const uint8_t &operator[](int index) const;
 
         /*!
          * @brief Sum operator return local buffer.
@@ -300,12 +305,7 @@ public:
          *
          * @return Current cursor instance.
          */
-        Cursor &operator+=(uint16_t n)
-        {
-            m_pos += n;
-            m_remaining -= n;
-            return *this;
-        }
+        Cursor &operator+=(uint16_t n);
 
         /*!
          * @brief Substract operator return local buffer.
@@ -314,41 +314,25 @@ public:
          *
          * @return Current cursor instance.
          */
-        Cursor &operator-=(uint16_t n)
-        {
-            m_pos -= n;
-            m_remaining += n;
-            return *this;
-        }
+        Cursor &operator-=(uint16_t n);
 
         /*!
          * @brief Sum +1 operator.
          *
          * @return Current cursor instance.
          */
-        Cursor &operator++(void)
-        {
-            ++m_pos;
-            --m_remaining;
-            return *this;
-        }
+        Cursor &operator++(void);
 
         /*!
          * @brief Substract -1 operator.
          *
          * @return Current cursor instance.
          */
-        Cursor &operator--(void)
-        {
-            --m_pos;
-            ++m_remaining;
-            return *this;
-        }
+        Cursor &operator--(void);
 
     private:
         MessageBuffer *m_buffer; /*!< Buffer for reading or writing data. */
         uint8_t *m_pos;          /*!< Position in buffer, where it last write/read */
-        uint16_t m_remaining;    /*!< Remaining space in buffer. */
     };
 
 private:


### PR DESCRIPTION
…uffer. (#297)

* Compare value length to used length () in reading data from message buffer.

Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

* Added check for appending data to the buffer.

we need be at the end of already written data.

Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

* Changes based on PR

Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

# Pull request

**Choose Correct**

- [ ] bug
- [ ] feature

**Describe the pull request**
<!--
A clear and concise description of what the pull request is.
-->

**To Reproduce**
<!--
Steps to reproduce the behavior.
-->

**Expected behavior**
<!--
A clear and concise description of what you expected to happen.
-->

**Screenshots**
<!--
If applicable, add screenshots to help explain your problem.
-->

**Desktop (please complete the following information):**

- OS<!--[e.g. iOS]-->:
- eRPC Version<!--[e.g. v1.9.0]-->:

**Steps you didn't forgot to do**

- [ ] I checked if other PR isn't solving this issue.
- [ ] I read Contribution details and did appropriate actions.
- [ ] PR code is tested.
- [ ] PR code is formatted.

**Additional context**
<!--
Add any other context about the problem here.
-->
